### PR TITLE
Fix inconsistent naming for PropertyLookup parser rule matches 

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
@@ -365,7 +365,7 @@
         eType="#//Expression3Part" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="nodeLabelList" upperBound="-1"
         eType="#//NodeLabel" containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="propertyLoopup" upperBound="-1"
+    <eStructuralFeatures xsi:type="ecore:EReference" name="propertyLookups" upperBound="-1"
         eType="#//PropertyLookup" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Expression3Part"/>
@@ -535,10 +535,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="IsNull" eSuperTypes="#//Expression3Part"/>
   <eClassifiers xsi:type="ecore:EClass" name="IsNotNull" eSuperTypes="#//Expression3Part"/>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionNodeLabelsAndPropertyLookup"
-      eSuperTypes="#//Expression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="propertyLookups" upperBound="-1"
-        eType="#//PropertyLookup" containment="true"/>
-  </eClassifiers>
+      eSuperTypes="#//Expression"/>
   <eClassifiers xsi:type="ecore:EClass" name="NumberConstant" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>

--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
@@ -269,7 +269,7 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//Expression/left"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//Expression/expression3Parts"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//Expression/nodeLabelList"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//Expression/propertyLoopup"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//Expression/propertyLookups"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//Expression3Part"/>
     <genClasses ecoreClass="OpenCypher.ecore#//Reduce">
@@ -396,9 +396,7 @@
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//IsNull"/>
     <genClasses ecoreClass="OpenCypher.ecore#//IsNotNull"/>
-    <genClasses ecoreClass="OpenCypher.ecore#//ExpressionNodeLabelsAndPropertyLookup">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionNodeLabelsAndPropertyLookup/propertyLookups"/>
-    </genClasses>
+    <genClasses ecoreClass="OpenCypher.ecore#//ExpressionNodeLabelsAndPropertyLookup"/>
     <genClasses ecoreClass="OpenCypher.ecore#//NumberConstant">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//NumberConstant/value"/>
     </genClasses>

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -795,7 +795,7 @@ PropertyExpression:
 /*
  * propertyExpression : atom ( ws propertyLookup )+ ;
  */
-	Atom (propertyLookup+=PropertyLookup)+;
+	Atom (propertyLookups+=PropertyLookup)+;
 
 PropertyKeyName:
 /*


### PR DESCRIPTION
See slizaa/slizaa-opencypher-xtext#3.