### PR TITLE
Remove '!=' operator

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher.ui/src/org/slizaa/neo4j/opencypher/ui/contentassist/OpenCypherProposalProvider.xtend
+++ b/plugins/org.slizaa.neo4j.opencypher.ui/src/org/slizaa/neo4j/opencypher/ui/contentassist/OpenCypherProposalProvider.xtend
@@ -19,7 +19,7 @@ import org.slizaa.neo4j.opencypher.ui.custom.spi.IGraphDatabaseClientAdapter
  */
 class OpenCypherProposalProvider extends AbstractOpenCypherProposalProvider {
 
-	private static final Set<String> WHITELIST_KEYWORDS = Sets.newHashSet("DISTINCT", "=", "<>", "!=", "<", ">", "<=",
+	private static final Set<String> WHITELIST_KEYWORDS = Sets.newHashSet("DISTINCT", "=", "<>", "<", ">", "<=",
 		">=", "NOT", "OR", "XOR", "AND");
 
 	override completeKeyword(Keyword keyword, ContentAssistContext contentAssistContext,

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -587,7 +587,6 @@ ExpressionComparison returns Expression:
  * 
  * partialComparisonExpression : ( '=' ws expression7 )
  *                             | ( '<>' ws expression7 )
- *                             | ( '!=' ws expression7 )
  *                             | ( '<' ws expression7 )
  *                             | ( '>' ws expression7 )
  *                             | ( '<=' ws expression7 )
@@ -595,7 +594,7 @@ ExpressionComparison returns Expression:
  * 
  * Comment: combined clause for 'expression8' and 'partialComparisonExpression'
  */
-	ExpressionPlusMinus ({ExpressionComparison.left=current} operator=('=' | '<>' | '!=' | '<' | '>' | '<=' | '>=')
+	ExpressionPlusMinus ({ExpressionComparison.left=current} operator=('=' | '<>' | '<' | '>' | '<=' | '>=')
 	right=ExpressionPlusMinus)*;
 
 ExpressionPlusMinus returns Expression:


### PR DESCRIPTION
The `!=` operator was [removed from openCypher](https://github.com/opencypher/openCypher/commit/0124f6994d08ced5ae0710c49b2cc709f0b46a34), so I updated the grammar and the proposal provider accordingly.