### PR TITLE
Model unary operators in a typed manner

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
@@ -508,6 +508,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ExpressionUnaryPlusMinus" eSuperTypes="#//Expression"/>
   <eClassifiers xsi:type="ecore:EClass" name="IndexExpression" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="expression" eType="#//Expression"
         containment="true"/>

--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
@@ -357,9 +357,6 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="upper" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Expression" eSuperTypes="#//PropertyExpression">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
-        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="nodeLabelList" upperBound="-1"
         eType="#//NodeLabel" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="propertyLookups" upperBound="-1"
@@ -481,64 +478,115 @@
   <eClassifiers xsi:type="ecore:EClass" name="ShortestPath" eSuperTypes="#//ShortestPathPattern"/>
   <eClassifiers xsi:type="ecore:EClass" name="AllShortestPaths" eSuperTypes="#//ShortestPathPattern"/>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionOr" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionXor" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionAnd" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ExpressionNot" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionComparison" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionPlusMinus" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionMulDiv" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionPower" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="ExpressionUnaryPlusMinus" eSuperTypes="#//Expression"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ExpressionUnaryPlusMinus" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="IndexExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="expression" eType="#//Expression"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="upper" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="RegExpMatchingExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="InCollectionExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="StartsWithExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EndsWithExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ContainsExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="IsNullExpression" eSuperTypes="#//Expression"/>
-  <eClassifiers xsi:type="ecore:EClass" name="IsNotNullExpression" eSuperTypes="#//Expression"/>
+  <eClassifiers xsi:type="ecore:EClass" name="IsNullExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="IsNotNullExpression" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ExpressionNodeLabelsAndPropertyLookup"
-      eSuperTypes="#//Expression"/>
+      eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NumberConstant" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>

--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
@@ -377,6 +377,7 @@
     <genClasses ecoreClass="OpenCypher.ecore#//ExpressionPower">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionPower/right"/>
     </genClasses>
+    <genClasses ecoreClass="OpenCypher.ecore#//ExpressionUnaryPlusMinus"/>
     <genClasses ecoreClass="OpenCypher.ecore#//IndexExpression">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//IndexExpression/expression"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//IndexExpression/upper"/>

--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
@@ -265,8 +265,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//RangeLiteral/upper"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//Expression">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//Expression/operator"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//Expression/left"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//Expression/nodeLabelList"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//Expression/propertyLookups"/>
     </genClasses>
@@ -357,49 +355,82 @@
     <genClasses ecoreClass="OpenCypher.ecore#//ShortestPath"/>
     <genClasses ecoreClass="OpenCypher.ecore#//AllShortestPaths"/>
     <genClasses ecoreClass="OpenCypher.ecore#//ExpressionOr">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionOr/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionOr/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionOr/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//ExpressionXor">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionXor/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionXor/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionXor/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//ExpressionAnd">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionAnd/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionAnd/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionAnd/right"/>
     </genClasses>
+    <genClasses ecoreClass="OpenCypher.ecore#//ExpressionNot">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionNot/operator"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionNot/left"/>
+    </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//ExpressionComparison">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionComparison/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionComparison/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionComparison/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//ExpressionPlusMinus">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionPlusMinus/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionPlusMinus/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionPlusMinus/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//ExpressionMulDiv">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionMulDiv/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionMulDiv/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionMulDiv/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//ExpressionPower">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionPower/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionPower/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionPower/right"/>
     </genClasses>
-    <genClasses ecoreClass="OpenCypher.ecore#//ExpressionUnaryPlusMinus"/>
+    <genClasses ecoreClass="OpenCypher.ecore#//ExpressionUnaryPlusMinus">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//ExpressionUnaryPlusMinus/operator"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionUnaryPlusMinus/left"/>
+    </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//IndexExpression">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//IndexExpression/left"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//IndexExpression/expression"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//IndexExpression/upper"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//RegExpMatchingExpression">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//RegExpMatchingExpression/left"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//RegExpMatchingExpression/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//InCollectionExpression">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//InCollectionExpression/left"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//InCollectionExpression/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//StartsWithExpression">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//StartsWithExpression/left"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//StartsWithExpression/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//EndsWithExpression">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//EndsWithExpression/left"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//EndsWithExpression/right"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//ContainsExpression">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ContainsExpression/left"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ContainsExpression/right"/>
     </genClasses>
-    <genClasses ecoreClass="OpenCypher.ecore#//IsNullExpression"/>
-    <genClasses ecoreClass="OpenCypher.ecore#//IsNotNullExpression"/>
-    <genClasses ecoreClass="OpenCypher.ecore#//ExpressionNodeLabelsAndPropertyLookup"/>
+    <genClasses ecoreClass="OpenCypher.ecore#//IsNullExpression">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//IsNullExpression/left"/>
+    </genClasses>
+    <genClasses ecoreClass="OpenCypher.ecore#//IsNotNullExpression">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//IsNotNullExpression/left"/>
+    </genClasses>
+    <genClasses ecoreClass="OpenCypher.ecore#//ExpressionNodeLabelsAndPropertyLookup">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//ExpressionNodeLabelsAndPropertyLookup/left"/>
+    </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//NumberConstant">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//NumberConstant/value"/>
     </genClasses>

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -579,7 +579,7 @@ ExpressionNot returns Expression:
  * Comment: Clause is modeled on the former antlr clause 'expression9 : ( sp NOT sp expression9 ) | expression8;'
  * We should eventually adjust this...
  */
-	(operator='NOT' left=ExpressionNot) | ExpressionComparison;
+	({ExpressionNot} operator='NOT' left=ExpressionNot) | ExpressionComparison;
 
 ExpressionComparison returns Expression:
 /*

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -619,10 +619,9 @@ ExpressionUnaryPlusMinus returns Expression:
 /*
  * expression4 : ( ( '+' | '-' ) ws )* expression3 ;
  * 
- * Comment: Clause is modeled on the former antlr clause 'expression4 : expression3 | ( ws '+' ws expression3 ) | ( ws '-' ws expression3 );'
- * We should eventually adjust this...
+ * Comment: In order to restrict our model for a single operator at a time, clause is modeled after a rewritetten form of the antlr clause 'expression4 : expression3 | ( ( '+' | '-' ) ws ) expression4;'
  */
-	Expression3 | operator=('+' | '-') left=Expression3;
+	Expression3 | {ExpressionUnaryPlusMinus} operator=('+' | '-') left=ExpressionUnaryPlusMinus;
 
 Expression3 returns Expression:
 /*


### PR DESCRIPTION
This PR modifies the openCypher Xtext grammar to model the following unary operators in a typed manner:
 - unary `+`/`-` are now modeled using `ExpressionUnaryPlusMinus`
 - unary `NOT` is now modeled using `ExpressionNot`

Previously, both of them where modeled using the general `Expression` EMF interface, and its operator attribute distinguished these kind of expressions from the very general `Expression` instances.

Note that the sequence of these 2 commits has the side effect to clean up the `Expression` interface by pushing down its `operator` and `left` attributes to the appropriate sub-interfaces.