### PR TITLE
Model enhancements: case and union

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher.ui/src/org/slizaa/neo4j/opencypher/ui/outline/OpenCypherOutlineTreeProvider.xtend
+++ b/plugins/org.slizaa.neo4j.opencypher.ui/src/org/slizaa/neo4j/opencypher/ui/outline/OpenCypherOutlineTreeProvider.xtend
@@ -4,9 +4,12 @@
 package org.slizaa.neo4j.opencypher.ui.outline
 
 import org.eclipse.xtext.EcoreUtil2
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.xtext.ui.editor.outline.IOutlineNode
 import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider
 import org.eclipse.xtext.ui.editor.outline.impl.DocumentRootNode
 import org.slizaa.neo4j.opencypher.openCypher.Cypher
+import org.slizaa.neo4j.opencypher.openCypher.CombinedQuery
 import org.slizaa.neo4j.opencypher.openCypher.SingleQuery
 import org.slizaa.neo4j.opencypher.openCypher.Statement
 import org.slizaa.neo4j.opencypher.openCypher.Clause
@@ -26,24 +29,32 @@ class OpenCypherOutlineTreeProvider extends DefaultOutlineTreeProvider {
 
 		for (element : EcoreUtil2.getAllContentsOfType(cypher, Statement)) {
 
-			if (element instanceof SingleQuery) {
-				val SingleQuery singleQuery = element as SingleQuery;
-				if (singleQuery.union.size > 0) {
+			if (element instanceof CombinedQuery) {
+				val CombinedQuery combinedQuery = element as CombinedQuery;
+				val SingleQuery singleQuery = combinedQuery.singleQuery;
 // TODO			
-//			createNode(parentNode, singleQuery);
-//			val IOutlineNode singleQueryParent = NodeModelUtils.getNode(singleQuery);
-//			for (clause : singleQuery.clauses) {
-//				createNode(singleQueryParent, clause);
-//			}
-				} else {
-					for (clause : singleQuery.clauses) {
-						createNode(parentNode, clause);
-					}
-				}
+//				createNode(parentNode, combinedQuery);
+//				val IOutlineNode combinedQueryParent = NodeModelUtils.getNode(combinedQuery); //FIXME: getNode does not return IOutlineNode
+//				createNode(combinedQueryParent, singleQuery);
+//				val IOutlineNode singleQueryParent = NodeModelUtils.getNode(singleQuery); //FIXME: getNode does not return IOutlineNode
+//				_addSingleQueryClauses(singleQueryParent, singleQuery);
+//				for (_union : combinedQuery.union) {
+//					createNode(combinedQueryParent, _union.singleQuery);
+//					val IOutlineNode _unionParent = NodeModelUtils.getNode(_union.singleQuery); //FIXME: getNode does not return IOutlineNode
+//					_addSingleQueryClauses(_unionParent, _union.singleQuery);
+//				}
+			} else if (element instanceof SingleQuery) {
+				val SingleQuery singleQuery = element as SingleQuery;
+				_addSingleQueryClauses(parentNode, singleQuery);
 			} else {
 				createNode(parentNode, element);
 			}
 		}
 	}
 
+	def void _addSingleQueryClauses(IOutlineNode parentNode, SingleQuery singleQuery) {
+		for (clause : singleQuery.clauses) {
+			createNode(parentNode, clause);
+		}
+	}
 }

--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
@@ -415,8 +415,6 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="propertyOperator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="CaseExpression" eSuperTypes="#//Expression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="expression" eType="#//CaseExpression"
-        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="caseAlternatives" upperBound="-1"
         eType="#//CaseAlternatives" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="caseExpression" eType="#//Expression"

--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
@@ -24,12 +24,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Statement"/>
   <eClassifiers xsi:type="ecore:EClass" name="Query" eSuperTypes="#//Statement"/>
-  <eClassifiers xsi:type="ecore:EClass" name="RegularQuery" eSuperTypes="#//Query">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="singleQuery" eType="#//RegularQuery"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="union" upperBound="-1"
-        eType="#//Union" containment="true"/>
-  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RegularQuery" eSuperTypes="#//Query"/>
   <eClassifiers xsi:type="ecore:EClass" name="BulkImportQuery" eSuperTypes="#//Query">
     <eStructuralFeatures xsi:type="ecore:EReference" name="periodicCommitHint" eType="#//PeriodicCommitHint"
         containment="true"/>
@@ -455,6 +450,12 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="profile" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="cypherOption" upperBound="-1"
         eType="#//CypherOption" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="CombinedQuery" eSuperTypes="#//RegularQuery">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="singleQuery" eType="#//SingleQuery"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="union" upperBound="-1"
+        eType="#//Union" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="IndexHint" eSuperTypes="#//Hint">
     <eStructuralFeatures xsi:type="ecore:EReference" name="variable" eType="#//Variable"

--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
@@ -24,10 +24,7 @@
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//Statement"/>
     <genClasses ecoreClass="OpenCypher.ecore#//Query"/>
-    <genClasses ecoreClass="OpenCypher.ecore#//RegularQuery">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//RegularQuery/singleQuery"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//RegularQuery/union"/>
-    </genClasses>
+    <genClasses ecoreClass="OpenCypher.ecore#//RegularQuery"/>
     <genClasses ecoreClass="OpenCypher.ecore#//BulkImportQuery">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//BulkImportQuery/periodicCommitHint"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//BulkImportQuery/loadCSVQuery"/>
@@ -338,6 +335,10 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//AllOptions/explain"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//AllOptions/profile"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//AllOptions/cypherOption"/>
+    </genClasses>
+    <genClasses ecoreClass="OpenCypher.ecore#//CombinedQuery">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//CombinedQuery/singleQuery"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//CombinedQuery/union"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//IndexHint">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//IndexHint/variable"/>

--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.genmodel
@@ -306,7 +306,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute OpenCypher.ecore#//PropertyLookup/propertyOperator"/>
     </genClasses>
     <genClasses ecoreClass="OpenCypher.ecore#//CaseExpression">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//CaseExpression/expression"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//CaseExpression/caseAlternatives"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//CaseExpression/caseExpression"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference OpenCypher.ecore#//CaseExpression/elseExpression"/>

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -674,7 +674,7 @@ Atom returns Expression:
  */
 	{NumberConstant} value=Number | {StringConstant} value=STRING_LITERAL | Parameter | LegacyParameter | {BoolConstant}
 	value=('TRUE' |
-	'FALSE') | {NullConstant} 'NULL' | {CaseExpression} expression=CaseExpression | {Count} 'COUNT' '(' '*' ')' |
+	'FALSE') | {NullConstant} 'NULL' | CaseExpression | {Count} 'COUNT' '(' '*' ')' |
 	MapLiteral | ListComprehension | {ExpressionList} ('[' expressions+=Expression (',' expressions+=Expression)* ']') |
 	{Filter} 'EXTRACT' '(' filterExpression=FilterExpression ('|' expression=Expression)? ')' | Reduce | {Filter}
 	'FILTER' '(' filterExpression=FilterExpression ')' | {All} 'ALL' '(' filterExpression=FilterExpression ')' | {Any}

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -57,7 +57,7 @@ RegularQuery:
 /*
  * regularQuery : singleQuery ( ws union )* ;
  */
-	SingleQuery ({RegularQuery.singleQuery=current} union+=Union)*;
+	SingleQuery ({CombinedQuery.singleQuery=current} ( union+=Union )+ )? ;
 
 BulkImportQuery:
 /*


### PR DESCRIPTION
This PR modifies the openCypher Xtext grammar in the following way:
 1. `CaseExpression` used to be wrapped in an other `CaseExpression`
 2. `UNION` of `SingleQuery`'s created a tree of unions. Now it is a list of the combined parts

Note that (2) was already suggested by the grammar. Now it is implemented. As a side effect, `singleQuery` and `union` attributes are pushed down from the `RegularQuery` interface to its new `CombinedQuery` subinterface. These attributes used to pollute the `SingleQuery` interface as they were always empty for `SingleQuery` instances.