### PR TITLE
Unwrap ReturnBody.returnItems from list to single reference

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
+++ b/plugins/org.slizaa.neo4j.opencypher/model/generated/OpenCypher.ecore
@@ -203,8 +203,8 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ReturnBody">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="returnItems" upperBound="-1"
-        eType="#//ReturnItems" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="returnItems" eType="#//ReturnItems"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="order" eType="#//Order"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="skip" eType="#//Skip" containment="true"/>

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -318,7 +318,7 @@ ReturnBody:
 /*
  * returnBody : returnItems ( sp order )? ( sp skip )? ( sp limit )? ;
  */
-	returnItems+=ReturnItems (order=Order)? (skip=Skip)? (limit=Limit)?;
+	returnItems=ReturnItems (order=Order)? (skip=Skip)? (limit=Limit)?;
 
 ReturnItems:
 /*


### PR DESCRIPTION
Previously, ReturnBody.returnItems was a single element list of ReturnItems
instance. This commit unwraps it from the list, so ReturnBody.returnItems
is now a direct reference to the ReturnItems instance.