### PR TITLE
Use path for testing FOREACH

### DIFF
--- a/tests/org.slizaa.neo4j.opencypher.tests/src/org/slizaa/neo4j/opencypher/tests/ForEach_Test.xtend
+++ b/tests/org.slizaa.neo4j.opencypher.tests/src/org/slizaa/neo4j/opencypher/tests/ForEach_Test.xtend
@@ -7,7 +7,7 @@ class ForEach_Test extends AbstractCypherTest {
 	@Test
 	def void forEach() {
 		test('''
-			MATCH (p)
+			MATCH p=()
 			FOREACH (n IN nodes(p)| SET n.marked = TRUE )
 		''');
 	}


### PR DESCRIPTION
The original query did not compile with Neo4j and returned the following error:

```
Type mismatch: expected Path but was Node (line 2, column 21 (offset: 30))
"FOREACH (n IN nodes(p) | SET n.marked = TRUE )"
                     ^
```

This commit fixes this. Might be useful in the future if someone decides to support type checking in the editor :-).