### PR TITLE
Add support for backticks, fixes #11

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -919,7 +919,7 @@ terminal SYMBOLIC_NAME:
 /*
  * Comment: reduced character set
  */
-	'^'? ('a'..'z' | 'A'..'Z' | '_') ('a'..'z' | 'A'..'Z' | '_' | '0'..'9')*;
+	('a'..'z' | 'A'..'Z' | '_') ('a'..'z' | 'A'..'Z' | '_' | '0'..'9')* | ('`' -> '`');
 
 terminal ML_COMMENT:
 	'/*'->'*/';

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypherRuntimeModule.xtend
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypherRuntimeModule.xtend
@@ -3,19 +3,25 @@
  */
 package org.slizaa.neo4j.opencypher
 
+import org.slizaa.neo4j.opencypher.conversion.OpenCypherIDValueConverter
 import org.slizaa.neo4j.opencypher.scoping.NullGlobalScopeProvider
+import org.slizaa.neo4j.opencypher.conversion.OpenCypherValueConverterService
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
  */
 class OpenCypherRuntimeModule extends AbstractOpenCypherRuntimeModule {
-	
-	override bindIFormatter2() {
-		super.bindIFormatter2()
-	}
 
 	override bindIGlobalScopeProvider() {
-		NullGlobalScopeProvider;
+		NullGlobalScopeProvider
+	}
+
+	override bindAbstractIDValueConverter() {
+		OpenCypherIDValueConverter
+	}
+
+	override bindIValueConverterService() {
+		OpenCypherValueConverterService
 	}
 	
 }

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/conversion/OpenCypherIDEscapeHelper.xtend
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/conversion/OpenCypherIDEscapeHelper.xtend
@@ -1,0 +1,56 @@
+package org.slizaa.neo4j.opencypher.conversion
+
+import com.google.common.collect.ImmutableSet
+import com.google.inject.Singleton
+import java.util.Set
+import java.util.regex.Pattern
+
+@Singleton
+class OpenCypherIDEscapeHelper {
+
+	static val UNESCAPED_ID_PATTERN = Pattern.compile('[a-zA-Z_][a-zA-Z0-9_]*')
+	static val char ESCAPE_CHAR = '`'
+	static val Set<Character> FORBIDDEN_CHARACTERS = #{0 as char, ESCAPE_CHAR}
+
+	def toValue(String string) {
+		if (string === null) {
+			null
+		} else if (string.charAt(0) == ESCAPE_CHAR) {
+			val length = string.length
+			string.substring(1, length - 1)
+		} else {
+			string
+		}
+	}
+
+	def mustEscape(String value) {
+		!UNESCAPED_ID_PATTERN.matcher(value).matches
+	}
+
+	def toEscapedString(String value) {
+		if (mustEscape(value)) {
+			ESCAPE_CHAR + value + ESCAPE_CHAR
+		} else {
+			value
+		}
+	}
+
+	def collectInvalidCharacters(String value) {
+		val invalidCharactersFound = ImmutableSet.builder
+		val length = value.length
+		for (var int i = 0; i < length; i++) {
+			val character = value.charAt(i)
+			if (FORBIDDEN_CHARACTERS.contains(character)) {
+				invalidCharactersFound.add(character)
+			}
+		}
+		val invalidChars = invalidCharactersFound.build
+		// org.eclipse.xtext.conversion.impl.AbstractLexerBasedConverter<T>#createTokenContentMismatchException requires `null` for valid strings.
+		if (invalidChars.empty) {
+			null
+		} else {
+			invalidChars
+		}
+	}
+
+}

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/conversion/OpenCypherIDValueConverter.xtend
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/conversion/OpenCypherIDValueConverter.xtend
@@ -1,0 +1,33 @@
+package org.slizaa.neo4j.opencypher.conversion
+
+import com.google.inject.Inject
+import org.eclipse.xtext.conversion.impl.IgnoreCaseIDValueConverter
+import org.eclipse.xtext.nodemodel.INode
+
+class OpenCypherIDValueConverter extends IgnoreCaseIDValueConverter {
+
+	@Inject
+	OpenCypherIDEscapeHelper helper
+
+	override toValue(String string, INode node) {
+		helper.toValue(string)
+	}
+
+	override protected assertValidValue(String value) {
+		// In Neo4j Cypher (as of 3.3.1) `` (empty string) is a valid ID.
+		// Omit call to super.assertValidValue, which would throw a ValueConverterException on empty values.
+	}
+
+	override protected mustEscape(String value) {
+		helper.mustEscape(value)
+	}
+
+	override protected toEscapedString(String value) {
+		helper.toEscapedString(value)
+	}
+
+	override protected collectInvalidCharacters(String value) {
+		helper.collectInvalidCharacters(value)
+	}
+
+}

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/conversion/OpenCypherValueConverterService.xtend
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/conversion/OpenCypherValueConverterService.xtend
@@ -1,0 +1,18 @@
+package org.slizaa.neo4j.opencypher.conversion
+
+import com.google.inject.Inject
+import org.eclipse.xtext.common.services.DefaultTerminalConverters
+import org.eclipse.xtext.conversion.IValueConverter
+import org.eclipse.xtext.conversion.ValueConverter
+
+class OpenCypherValueConverterService extends DefaultTerminalConverters {
+
+	@Inject
+	SYMBOLIC_NAME_XValueConverter symbolNameXValueConverter
+
+	@ValueConverter(rule="SYMBOLIC_NAME_X")
+	def IValueConverter<String> SYMBOLIC_NAME_X() {
+		symbolNameXValueConverter
+	}
+
+}

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/conversion/SYMBOLIC_NAME_XValueConverter.xtend
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/conversion/SYMBOLIC_NAME_XValueConverter.xtend
@@ -1,0 +1,34 @@
+package org.slizaa.neo4j.opencypher.conversion
+
+import com.google.common.base.Joiner
+import com.google.inject.Inject
+import java.util.Set
+import org.eclipse.xtext.conversion.ValueConverterException
+import org.eclipse.xtext.conversion.impl.AbstractValueConverter
+import org.eclipse.xtext.nodemodel.INode
+
+class SYMBOLIC_NAME_XValueConverter extends AbstractValueConverter<String> {
+
+	@Inject
+	OpenCypherIDEscapeHelper helper
+
+	override toString(String value) throws ValueConverterException {
+		val invalidChars = helper.collectInvalidCharacters(value)
+		if (invalidChars === null) {
+			helper.toEscapedString(value)
+		} else {
+			throw new ValueConverterException(getInvalidCharactersMessage(value, invalidChars), null, null)
+		}
+	}
+
+	// Copied from org.eclipse.xtext.conversion.impl.AbstractIDValueConverter#getInvalidCharactersMessage
+	protected def getInvalidCharactersMessage(String value, Set<Character> invalidChars) {
+		val chars = Joiner.on(", ").join(invalidChars.map[from|"'" + from + "' (0x" + Integer.toHexString(from) + ")"])
+		"ID '" + value + "' contains invalid characters: " + chars
+	}
+
+	override toValue(String string, INode node) throws ValueConverterException {
+		helper.toValue(string)
+	}
+
+}

--- a/tests/org.slizaa.neo4j.opencypher.tests/src/org/slizaa/neo4j/opencypher/tests/Backtick_Test.xtend
+++ b/tests/org.slizaa.neo4j.opencypher.tests/src/org/slizaa/neo4j/opencypher/tests/Backtick_Test.xtend
@@ -1,0 +1,44 @@
+package org.slizaa.neo4j.opencypher.tests
+
+import org.junit.Test
+import org.slizaa.neo4j.opencypher.openCypher.Cypher
+import org.eclipse.xtext.EcoreUtil2
+import org.eclipse.emf.ecore.util.EcoreUtil
+import java.util.Collections
+import org.slizaa.neo4j.opencypher.openCypher.ReturnItems
+import org.slizaa.neo4j.opencypher.openCypher.ReturnItem
+import java.util.List
+import org.slizaa.neo4j.opencypher.openCypher.FunctionInvocation
+import static com.google.common.base.Preconditions.checkNotNull
+import junit.framework.Assert
+
+class Backtick_Test extends AbstractCypherTest {
+
+	@Test
+	def void backtick_1() {
+		test('''
+			MATCH (`person_a`:Person {test:'Jim'})-[:KNOWS]->(`person_b`)-[:KNOWS]->(`person_c`),
+			(`person_a`)-[:KNOWS]->(`person_c`)
+			RETURN `person_a`, `person_c`
+		''');
+	}
+
+	@Test
+	def void backtick_2() {
+		test('''
+			MATCH (`person_a`:Person {test:'Jim'})-[:KNOWS]->(`person_b`)-[:KNOWS]->(`person_c`),
+			(`person_a`)-[:KNOWS]->(`person_c`)
+			RETURN person_a, person_c
+		''');
+	}
+
+	@Test
+	def void backtick_3() {
+		test('''
+			MATCH (`person a`:Person {test:'Jim'})-[:KNOWS]->(`person b`)-[:KNOWS]->(`person c`),
+			(`person a`)-[:KNOWS]->(`person c`)
+			RETURN `person a`, `person c`
+		''');
+	}
+
+}


### PR DESCRIPTION
Names surrounded by backticks are equivalent to bare names unless they contain special characters.
Implementation follows Neo4j Cypher 3.3.1 (and the openCypher ANTLR4 grammar), permitting `` as a valid name.

Signed-off-by: Gabor Szarnyas <szarnyasg@gmail.com>

Most of the credit goes to @kris7t 