### PR TITLE
Allow WHERE to use variables from the same MATCH/WITH clause. Fixes #24

### DIFF
--- a/tests/org.slizaa.neo4j.opencypher.tests/src/org/slizaa/neo4j/opencypher/tests/Where_Test.xtend
+++ b/tests/org.slizaa.neo4j.opencypher.tests/src/org/slizaa/neo4j/opencypher/tests/Where_Test.xtend
@@ -1,0 +1,16 @@
+package org.slizaa.neo4j.opencypher.tests
+
+import org.junit.Test
+
+class Where_Test extends AbstractCypherTest {
+
+	@Test
+	def void whereAlias() {
+		test('''
+			MATCH (p:Person)-->(c:Car)
+			WITH p, count(c) AS carNumber
+			WHERE carNumber > 1
+			RETURN p
+		''');
+	}
+}


### PR DESCRIPTION
Also added the test case presented in #24.