### PR TITLE
Fine tune modelling of expressions

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -876,7 +876,7 @@ PropertyExpression:
 /*
  * propertyExpression : atom ( ws propertyLookup )+ ;
  */
-	Atom (propertyLookups+=PropertyLookup)+;
+	left=Atom propertyLookups+=PropertyLookup+;
 
 PropertyKeyName:
 /*

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -666,10 +666,15 @@ Expression3 returns Expression:
 
 ExpressionNodeLabelsAndPropertyLookup returns Expression:
 /*
- * expression2 : atom ( propertyLookup | nodeLabels )* ;
+ * this is a clarified and corrected form of openCypher spec M08 version which had ambiguity
+ * oC_PropertyOrLabelsExpression : oC_Atom ( SP? oC_PropertyLookup )* ( SP? oC_NodeLabels )?
+ *
+ * Note: we want ExpressionPropertyLookup and ExpressionNodeLabelsConstraint to
+ * appear in the AST iff property lookups and node label constraints were given, respectively
  */
-	Atom ({ExpressionNodeLabelsAndPropertyLookup.left=current} propertyLookups+=PropertyLookup |
-	nodeLabelList+=NodeLabel)*;
+	Atom ({ExpressionPropertyLookup.left=current} propertyLookups+=PropertyLookup+)?
+	     ({ExpressionNodeLabels.left=current} nodeLabels+=NodeLabel+)?
+	;
 
 /* Expression1 */
 Atom returns Expression:

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -293,7 +293,7 @@ RemoveItem:
  * removeItem : ( variable nodeLabels )
  *              | propertyExpression;
  */
-	(variable=VariableDeclaration nodeLabels=NodeLabels) | PropertyExpression;
+	({RemoveItemLabel} variable=VariableDeclaration nodeLabels=NodeLabels) | {RemoveItemProperty} propertyExpression=PropertyExpression;
 
 Foreach:
 /*


### PR DESCRIPTION
The expression hierarchy have had some anti-semantic inheritance in place.

This PR addresses these issues:
 - `RemoveItem` used to be a superinterface of `PropertyExpression`
 - `PropertyExpression` used to be a superinterface of `Expression`, because `Atom` returns an `Expression`.

Also `ExpressionNodeLabelsAndPropertyLookup` interface was split into two interfaces, namely
 - `ExpressionPropertyLookup` and
 - `ExpressionNodeLabels`

both of them describing a list of property lookup and node label constraints, respectively.

The following diff of the ecore model shows the effect:

```diff
--- /home/jmarton/temp/OpenCypher.ecore.2018012000	2018-01-21 02:38:19.353833713 +0100
+++ /home/jmarton/temp/OpenCypher.ecore.2018012003	2018-01-21 02:36:11.421780035 +0100
@@ -175,12 +175,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="removeItems" upperBound="-1"
         eType="#//RemoveItem" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="RemoveItem">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="variable" eType="#//VariableDeclaration"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="nodeLabels" eType="#//NodeLabels"
-        containment="true"/>
-  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RemoveItem"/>
   <eClassifiers xsi:type="ecore:EClass" name="Foreach" eSuperTypes="#//Clause">
     <eStructuralFeatures xsi:type="ecore:EReference" name="variable" eType="#//VariableDeclaration"
         containment="true"/>
@@ -372,12 +367,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="lower" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="upper" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="Expression" eSuperTypes="#//PropertyExpression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="nodeLabelList" upperBound="-1"
-        eType="#//NodeLabel" containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="propertyLookups" upperBound="-1"
-        eType="#//PropertyLookup" containment="true"/>
-  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Expression"/>
   <eClassifiers xsi:type="ecore:EClass" name="Reduce" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="accumulator" eType="#//VariableDeclaration"
         containment="true"/>
@@ -479,7 +469,12 @@
   <eClassifiers xsi:type="ecore:EClass" name="Parameter" eSuperTypes="#//Properties #//Expression">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="parameter" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="PropertyExpression" eSuperTypes="#//RemoveItem"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PropertyExpression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="propertyLookups" upperBound="-1"
+        eType="#//PropertyLookup" containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="DecimalInteger">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
@@ -495,6 +490,16 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="union" upperBound="-1"
         eType="#//Union" containment="true"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RemoveItemLabel" eSuperTypes="#//RemoveItem">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="variable" eType="#//VariableDeclaration"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nodeLabels" eType="#//NodeLabels"
+        containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="RemoveItemProperty" eSuperTypes="#//RemoveItem">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="propertyExpression" eType="#//PropertyExpression"
+        containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="IndexHint" eSuperTypes="#//Hint">
     <eStructuralFeatures xsi:type="ecore:EReference" name="variable" eType="#//VariableDeclaration"
         containment="true"/>
@@ -619,10 +624,17 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="ExpressionNodeLabelsAndPropertyLookup"
-      eSuperTypes="#//Expression">
+  <eClassifiers xsi:type="ecore:EClass" name="ExpressionPropertyLookup" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
         containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="propertyLookups" upperBound="-1"
+        eType="#//PropertyLookup" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ExpressionNodeLabels" eSuperTypes="#//Expression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="nodeLabels" upperBound="-1"
+        eType="#//NodeLabel" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NumberConstant" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
```