### PR TITLE
Labels and properties to fragment [not ready for merging]

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -372,7 +372,7 @@ RemoveItem:
  *               | oC_PropertyExpression
  *               ;
  */
-	(variable=VariableDeclaration nodeLabels=NodeLabels) | PropertyExpression;
+	({RemoveItemLabel} variable=VariableDeclaration nodeLabels=NodeLabels) | {RemoveItemProperty} propertyExpression=PropertyExpression;
 
 Foreach:
 /*

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -352,7 +352,7 @@ SetItem:
  */
 	(propertyExpression=PropertyExpression '=' expression=Expression) | (variable=VariableDeclaration '='
 	expression=Expression) | (variable=VariableDeclaration '+=' expression=Expression) | (variable=VariableDeclaration
-	nodeLabels=NodeLabels);
+	NodeLabels);
 
 Delete:
 /*
@@ -372,7 +372,7 @@ RemoveItem:
  *               | oC_PropertyExpression
  *               ;
  */
-	({RemoveItemLabel} variable=VariableDeclaration nodeLabels=NodeLabels) | {RemoveItemProperty} propertyExpression=PropertyExpression;
+	({RemoveItemLabel} variable=VariableDeclaration NodeLabels) | {RemoveItemProperty} propertyExpression=PropertyExpression;
 
 Foreach:
 /*
@@ -579,7 +579,7 @@ NodePattern:
 /*
  * oC_NodePattern : '(' SP? ( oC_Variable SP? )? ( oC_NodeLabels SP? )? ( oC_Properties SP? )? ')' ;
  */
-	{NodePattern} '(' variable=VariableDeclaration? nodeLabels=NodeLabels? properties=Properties? ')';
+	{NodePattern} '(' variable=VariableDeclaration? NodeLabels? properties=Properties? ')';
 
 PatternElementChain:
 /*
@@ -625,11 +625,11 @@ RelationshipTypes:
  */
 	':' relTypeName+=RelTypeName ('|' ':'? relTypeName+=RelTypeName)*;
 
-NodeLabels:
+fragment NodeLabels:
 /*
  * oC_NodeLabels : oC_NodeLabel ( SP? oC_NodeLabel )* ;
  */
-	nodeLabels+=NodeLabel (nodeLabels+=NodeLabel)*;
+	nodeLabels+=NodeLabel+;
 
 NodeLabel:
 /*
@@ -752,8 +752,8 @@ PropertyOrLabelsExpression returns Expression:
 /*
  * oC_PropertyOrLabelsExpression : oC_Atom ( SP? oC_PropertyLookup )* ( SP? oC_NodeLabels )? ;
  */
-	Atom ({PropertyOrLabelsExpression.left=current} propertyLookups+=PropertyLookup |
-	nodeLabelList+=NodeLabel)*;
+	Atom ({PropertyOrLabelsExpression.left=current} propertyLookups+=PropertyLookup+)?
+	     ({PropertyOrLabelsExpression.left=current} NodeLabels)?;
 
 Atom returns Expression:
 /*


### PR DESCRIPTION
Node labels and property lookup expressions are an essential part of the openCypher language. They are currently modeled in the Xtext grammar as member objects, i.e. for a `NodePattern` instance `n`, one can access the associated labels through the `n.nodeLabels.nodeLabels` list as defined by the code snippets referenced below.

https://github.com/slizaa/slizaa-opencypher-xtext/blob/d24e69870b681a2c53be4f065485de1875afe564/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext#L578-L582

https://github.com/slizaa/slizaa-opencypher-xtext/blob/d24e69870b681a2c53be4f065485de1875afe564/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext#L628-L632

My proposal is to remove one hierarchy level from this modeling by introducing fragments as illustrated below, which should allow accessing labels in a `NodePattern` instance `n` as the list `n.nodeLabels`

https://github.com/jmarton/slizaa-opencypher-xtext/blob/77cf4c29f43332d62881fee5dd24f487b24a2181/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext#L628-L632

https://github.com/jmarton/slizaa-opencypher-xtext/blob/77cf4c29f43332d62881fee5dd24f487b24a2181/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext#L578-L582