### PR TITLE
openCypher M10 grammar revision 01

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher/pom.xml
+++ b/plugins/org.slizaa.neo4j.opencypher/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.slizaa.neo4j.opencypher</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<jdt-core-version>3.12.2</jdt-core-version>
+	</properties>
+
 	<build>
 
 		<sourceDirectory>src</sourceDirectory>
@@ -141,6 +145,14 @@
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
+				<dependencies>
+					<!-- https://github.com/eclipse/xtext/issues/1231#issuecomment-402193047 -->
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.core</artifactId>
+						<version>${jdt-core-version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>

--- a/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
+++ b/plugins/org.slizaa.neo4j.opencypher/src/org/slizaa/neo4j/opencypher/OpenCypher.xtext
@@ -122,6 +122,12 @@ MultiPartSubQuery:
  */
 	(readingClause+=ReadingClause)* (updatingClauses+=UpdatingClause)* withPart=With;
 
+Clause:
+/*
+ * Comment: introduced Clause to have a common superinterface for the different clause types. This comes handy when dealing with the ASG.
+ */
+	UpdatingClause | ReadingClause | Return | With;
+
 UpdatingClause:
 /*
  * oC_UpdatingClause : oC_Create


### PR DESCRIPTION
This PR adds two minor things:
 - workaround for a recent Xtext maven issue
 - Clause as a common superinterface for the different clause types

Ref. #23