### PR TITLE
Bump version to 9.12.0-SNAPSHOT

### DIFF
--- a/plugins/org.slizaa.neo4j.opencypher.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.slizaa.neo4j.opencypher.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.slizaa.neo4j.opencypher.ide
 Bundle-Vendor: My Company
-Bundle-Version: 9.11.0.qualifier
+Bundle-Version: 9.12.0.qualifier
 Bundle-SymbolicName: org.slizaa.neo4j.opencypher.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.slizaa.neo4j.opencypher,

--- a/plugins/org.slizaa.neo4j.opencypher.ide/pom.xml
+++ b/plugins/org.slizaa.neo4j.opencypher.ide/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.slizaa.neo4j.opencypher</groupId>
 		<artifactId>org.slizaa.neo4j.opencypher.parent</artifactId>
-		<version>9.11.0-SNAPSHOT</version>
+		<version>9.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.slizaa.neo4j.opencypher.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.slizaa.neo4j.opencypher.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.slizaa.neo4j.opencypher.ui
 Bundle-Vendor: My Company
-Bundle-Version: 9.11.0.qualifier
+Bundle-Version: 9.12.0.qualifier
 Bundle-SymbolicName: org.slizaa.neo4j.opencypher.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.slizaa.neo4j.opencypher,

--- a/plugins/org.slizaa.neo4j.opencypher.ui/pom.xml
+++ b/plugins/org.slizaa.neo4j.opencypher.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.slizaa.neo4j.opencypher</groupId>
 		<artifactId>org.slizaa.neo4j.opencypher.parent</artifactId>
-		<version>9.11.0-SNAPSHOT</version>
+		<version>9.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.slizaa.neo4j.opencypher/META-INF/MANIFEST.MF
+++ b/plugins/org.slizaa.neo4j.opencypher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.slizaa.neo4j.opencypher
 Bundle-Vendor: My Company
-Bundle-Version: 9.11.0.qualifier
+Bundle-Version: 9.12.0.qualifier
 Bundle-SymbolicName: org.slizaa.neo4j.opencypher; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/plugins/org.slizaa.neo4j.opencypher/pom.xml
+++ b/plugins/org.slizaa.neo4j.opencypher/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.slizaa.neo4j.opencypher</groupId>
 		<artifactId>org.slizaa.neo4j.opencypher.parent</artifactId>
-		<version>9.11.0-SNAPSHOT</version>
+		<version>9.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.slizaa.neo4j.opencypher</groupId>
 	<artifactId>org.slizaa.neo4j.opencypher.parent</artifactId>
-	<version>9.11.0-SNAPSHOT</version>
+	<version>9.12.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/releng/org.slizaa.neo4j.opencypher.feature/feature.xml
+++ b/releng/org.slizaa.neo4j.opencypher.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.slizaa.neo4j.opencypher.feature"
       label="org.slizaa.neo4j.opencypher.feature"
-      version="9.11.0.qualifier">
+      version="9.12.0.qualifier">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/releng/org.slizaa.neo4j.opencypher.feature/pom.xml
+++ b/releng/org.slizaa.neo4j.opencypher.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.slizaa.neo4j.opencypher</groupId>
 		<artifactId>org.slizaa.neo4j.opencypher.parent</artifactId>
-		<version>9.11.0-SNAPSHOT</version>
+		<version>9.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/org.slizaa.neo4j.opencypher.p2/pom.xml
+++ b/releng/org.slizaa.neo4j.opencypher.p2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.slizaa.neo4j.opencypher</groupId>
 		<artifactId>org.slizaa.neo4j.opencypher.parent</artifactId>
-		<version>9.11.0-SNAPSHOT</version>
+		<version>9.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/org.slizaa.neo4j.opencypher.target/pom.xml
+++ b/releng/org.slizaa.neo4j.opencypher.target/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.slizaa.neo4j.opencypher</groupId>
 		<artifactId>org.slizaa.neo4j.opencypher.parent</artifactId>
-		<version>9.11.0-SNAPSHOT</version>
+		<version>9.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<packaging>eclipse-target-definition</packaging>

--- a/tests/org.slizaa.neo4j.opencypher.tests/META-INF/MANIFEST.MF
+++ b/tests/org.slizaa.neo4j.opencypher.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.slizaa.neo4j.opencypher.tests
 Bundle-Vendor: My Company
-Bundle-Version: 9.11.0.qualifier
+Bundle-Version: 9.12.0.qualifier
 Bundle-SymbolicName: org.slizaa.neo4j.opencypher.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.slizaa.neo4j.opencypher,

--- a/tests/org.slizaa.neo4j.opencypher.tests/pom.xml
+++ b/tests/org.slizaa.neo4j.opencypher.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.slizaa.neo4j.opencypher</groupId>
 		<artifactId>org.slizaa.neo4j.opencypher.parent</artifactId>
-		<version>9.11.0-SNAPSHOT</version>
+		<version>9.12.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/org.slizaa.neo4j.opencypher.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.slizaa.neo4j.opencypher.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.slizaa.neo4j.opencypher.ui.tests
 Bundle-Vendor: My Company
-Bundle-Version: 9.11.0.qualifier
+Bundle-Version: 9.12.0.qualifier
 Bundle-SymbolicName: org.slizaa.neo4j.opencypher.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.slizaa.neo4j.opencypher.ui,

--- a/update-version.xml
+++ b/update-version.xml
@@ -1,13 +1,13 @@
 <project name="update-version" basedir="." default="update-version">
 
-	<property name="old.mvn.version" value="9.10.0-SNAPSHOT" />
-	<property name="new.mvn.version" value="9.11.0-SNAPSHOT" />
+	<property name="old.mvn.version" value="9.11.0-SNAPSHOT" />
+	<property name="new.mvn.version" value="9.12.0-SNAPSHOT" />
 	
-	<property name="old.pde.version" value="9.10.0.qualifier" />
-	<property name="new.pde.version" value="9.11.0.qualifier" />
+	<property name="old.pde.version" value="9.11.0.qualifier" />
+	<property name="new.pde.version" value="9.12.0.qualifier" />
 
-	<property name="old.pde.requirebundle.version" value="9.10.0" />
-	<property name="new.pde.requirebundle.version" value="9.11.0" />
+	<property name="old.pde.requirebundle.version" value="9.11.0" />
+	<property name="new.pde.requirebundle.version" value="9.12.0" />
 
 	<!-- ================================= 
           target: update-version              


### PR DESCRIPTION
The openCypher grammar did not change between milestones M10 and M11:
https://github.com/opencypher/openCypher/compare/1.0.0-M10...1.0.0-M11
(The grammar xml files were extended with comments on the license, but their contents were not modified.)

I updated the `update-version.xml` according to this. I tried to bump the version with `mvn release:update-versions`, but it did not work. Please advise on how this should be done -- I am not an expert in bumping versions with Maven and usually just do a search-and-replace manually.